### PR TITLE
Bug fixes in extracting RADIUS user role

### DIFF
--- a/src/ap/ieee802_1x.c
+++ b/src/ap/ieee802_1x.c
@@ -1905,7 +1905,8 @@ struct radius_vendor_specific_info {
 
 #define RADIUS_VENDOR_ID_ARUBA (14823)
 enum {
-	RADIUS_VENDOR_ATTR_ARUBA_USER_GROUP = 36
+	RADIUS_VENDOR_ATTR_ARUBA_WIRED_USER_GROUP = 36,
+	RADIUS_VENDOR_ATTR_ARUBA_WIRELESS_USER_GROUP = 1
 };
 
 static void
@@ -1935,7 +1936,13 @@ aruba_store_role(struct hostapd_data *hapd,
 struct radius_vendor_specific_info g_radius_supported_vsi[] = {
 	{
 		.vsi_vendorid = 14823,
-		.vsi_subtype = RADIUS_VENDOR_ATTR_ARUBA_USER_GROUP,
+		.vsi_subtype = RADIUS_VENDOR_ATTR_ARUBA_WIRED_USER_GROUP,
+		.vsi_vendorname = "Aruba",
+		.vsi_storecb = aruba_store_role
+	},
+	{
+		.vsi_vendorid = 14823,
+		.vsi_subtype = RADIUS_VENDOR_ATTR_ARUBA_WIRELESS_USER_GROUP,
 		.vsi_vendorname = "Aruba",
 		.vsi_storecb = aruba_store_role
 	}
@@ -1959,9 +1966,10 @@ ieee802_1x_store_supported_vendor_attrs(struct radius_msg *msg,
 		if (attr == NULL || alen == 0) {
 			hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE8021X,
 						   HOSTAPD_LEVEL_INFO,
-						   "cannot find vendorid %d, vendor name %s",
+						   "### cannot find vendorid %d, vendor name %s, subtype: %d",
 						   g_radius_supported_vsi[ii].vsi_vendorid,
-						   g_radius_supported_vsi[ii].vsi_vendorname);
+						   g_radius_supported_vsi[ii].vsi_vendorname,
+						   g_radius_supported_vsi[ii].vsi_subtype);
 			continue;
 		}
 
@@ -1969,9 +1977,10 @@ ieee802_1x_store_supported_vendor_attrs(struct radius_msg *msg,
 		os_snprintf(attr_as_str, alen + 1, "%s", attr);
 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE8021X,
 					   HOSTAPD_LEVEL_INFO,
-					   "found vendorid %d, vendor name %s attr=%s",
+					   "found vendorid %d, vendor name %s, subtype: %d, attr=%s",
 					   g_radius_supported_vsi[ii].vsi_vendorid,
 					   g_radius_supported_vsi[ii].vsi_vendorname,
+					   g_radius_supported_vsi[ii].vsi_subtype,
 					   attr_as_str);
 		if (g_radius_supported_vsi[ii].vsi_storecb) {
 			g_radius_supported_vsi[ii].vsi_storecb(hapd,

--- a/src/ap/sta_info.c
+++ b/src/ap/sta_info.c
@@ -1221,6 +1221,7 @@ const char * ap_sta_wpa_get_keyid(struct hostapd_data *hapd,
 }
 
 
+#define INF_UNKNOWN_PARAM_VALUE "__ignore__"
 void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 			   int authorized)
 {
@@ -1260,7 +1261,7 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 	if (strlen(hapd->conf->bridge) > 0) {
 		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s ", hapd->conf->bridge);
 	} else {
-		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s ", "__ignore__");
+		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s ", INF_UNKNOWN_PARAM_VALUE);
 	}
 	pbuf += sz;
 
@@ -1271,7 +1272,7 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 			pbuf += sta->eapol_sm->identity_len;
 			wpa_printf(MSG_INFO, "INFWIRED: AUTH sending username %s", buf);
 		} else {
-			sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s", "__ignore__");
+			sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s ", INF_UNKNOWN_PARAM_VALUE);
 			pbuf += sz;
 		}
 	}
@@ -1284,7 +1285,7 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 			wpa_printf(MSG_INFO, "INFWIRED: AUTH sending userole %s", buf);
 		}
 	} else {
-		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s", "__ignore__");
+		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s", INF_UNKNOWN_PARAM_VALUE);
 	}
 
 	


### PR DESCRIPTION
There seems to be a behaviour difference where the vendor
sub attribute that specifies the role changes depending
on some configuration in clearpass. Adding code to ensure that
all those sub attributes are checked to extract the role.