### PR TITLE
Bug fixes for hostapd to consume Infiot auth cfg

### DIFF
--- a/hostapd/Makefile
+++ b/hostapd/Makefile
@@ -24,8 +24,13 @@ endif
 CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -I$(abspath ../src)
 CFLAGS += -I$(abspath ../src/utils)
+CFLAGS += -DCONFIG_INF_AUTH
 
 export BINDIR ?= /usr/local/bin/
+
+ifdef CONFIG_INF_AUTH
+CLFAGS += -DCONFIG_INF_AUTH
+endif
 
 ifdef CONFIG_INF_WIRED_PAE
 CLFAGS += -DCONFIG_INF_WIRED_PAE
@@ -1297,6 +1302,7 @@ ifdef CONFIG_CODE_COVERAGE
 	$(Q)cd $(dir $@); $(CC) -c -o $(notdir $@) $(CFLAGS) $(notdir $<)
 else
 %.o: %.c
+	echo "Infiot print" $(CFLAGS)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 	@$(E) "  CC " $<
 endif

--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2445,7 +2445,7 @@ static void inf_auth_print_params(struct infiot_auth_params *auth)
 	int ii = 0;
 	int num_users = auth->num_users;
 	for (ii = 0; ii < num_users; ii++) {
-		wpa_printf(MSG_INFO, "INFAUTH vlan member %d is %s",
+		wpa_printf(MSG_INFO, "INFAUTH user %d is %s",
 				   ii,
 				   auth->user_list[ii]);
 	}
@@ -2518,11 +2518,10 @@ static int inf_auth_parse_params(struct infiot_auth_params *auth, char *pos)
 	return 0;
 }
 
-static int hostapd_config_read_infiot_params(struct hostapd_bss_config *bss, char *fname, char *line)
+static int hostapd_config_read_infiot_params(struct hostapd_bss_config *bss, char *fname)
 {
 	FILE *f;
 	char buf[512], *pos;
-	int line = 0;
 	struct infiot_auth_params *auth;
 
     while (*fname == ' ' || *fname == '=')
@@ -2541,11 +2540,11 @@ static int hostapd_config_read_infiot_params(struct hostapd_bss_config *bss, cha
 			pos = pos + strlen(INF_USER_TAG);
 			while (*pos == ' ' || *pos == '\t' || *pos == '=')
 				pos++;
-			inf_auth_parse_params(*auth, pos);
+			inf_auth_parse_params(auth, pos);
 		}
 	}
 
-	bss->inf_auth = auth
+	bss->inf_auth = auth;
 	bss->inf_num_auth_params = 1; //For now it just indicates only user auth is used
 
 	fclose(f);
@@ -4702,7 +4701,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
 #endif
 #ifdef CONFIG_INF_AUTH
 	} else if (os_strcmp(buf, INFIOT_AUTH_CFG_FILE) == 0) {
-		hostapd_config_read_infiot_params(bss, pos, line);
+		hostapd_config_read_infiot_params(bss, pos);
 #endif
 	} else {
 		wpa_printf(MSG_ERROR,

--- a/src/ap/ap_config.c
+++ b/src/ap/ap_config.c
@@ -697,13 +697,13 @@ static void hostapd_config_free_inf_auth_members(struct hostapd_bss_config *bss)
 				   bss->inf_num_auth_params);
 		return;
 	}
-	struct *inf_auth_params = bss->inf_auth;
+	struct infiot_auth_params *inf_auth_params = bss->inf_auth;
 	char **user_list = inf_auth_params->user_list; 
 	for (ii = 0; ii < inf_auth_params->num_users; ii++) {
-		free(bss->inf_auth_members[ii]);
+		free(user_list[ii]);
 	}
 	free (user_list);
-	free(bss->inf_auth_members);
+	free(bss->inf_auth);
 
 	return;
 }
@@ -770,6 +770,8 @@ void hostapd_config_free_bss(struct hostapd_bss_config *conf)
 #ifdef CONFIG_INF_WIRED_PAE
 	hostapd_config_free_bss_vlan_members(conf);
 #endif
+#ifdef CONFIG_INF_AUTH
+	hostapd_config_free_inf_auth_members(conf);
 	os_free(conf->time_zone);
 
 #ifdef CONFIG_IEEE80211R_AP

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -266,6 +266,8 @@ struct airtime_sta_weight {
 };
 
 #ifdef CONFIG_INF_AUTH
+#define INF_USER_TAG "users"
+#define INFIOT_AUTH_CFG_FILE "infiot_auth_file"
 struct infiot_auth_params {
        char **user_list;
        int num_users;
@@ -285,7 +287,11 @@ struct hostapd_bss_config {
 	int num_vlan_members;
 #endif
 #ifdef CONFIG_INF_AUTH
+<<<<<<< HEAD
 	struct *infiot_auth_params inf_auth;
+=======
+	struct infiot_auth_params *inf_auth;
+>>>>>>> ca1e8b8b1... Modify hostapd to consume Infiot auth config
 	int inf_num_auth_params;
 #endif
 	enum hostapd_logger_level logger_syslog_level, logger_stdout_level;


### PR DESCRIPTION
Bug fixed on to enable hostapd config to consume Infiot specific
authentication information

Re #8614