### PR TITLE
Fix user id failures when group is unknown

### DIFF
--- a/src/ap/sta_info.c
+++ b/src/ap/sta_info.c
@@ -1285,7 +1285,7 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
 			wpa_printf(MSG_INFO, "INFWIRED: AUTH sending userole %s", buf);
 		}
 	} else {
-		sz = os_snprintf(pbuf, pbufend - pbuf + 1, "%s", INF_UNKNOWN_PARAM_VALUE);
+		sz = os_snprintf(pbuf, pbufend - pbuf + 1, " %s", INF_UNKNOWN_PARAM_VALUE);
 	}
 
 	


### PR DESCRIPTION
When group is unknown, we set the group name as "ignore" - but
there was a bug in this print which led to this string getting
added to the user name instead of appearing separately.