### PR TITLE
wpa_supplicant support to do perpetual normal scan

### DIFF
--- a/wpa_supplicant/scan.c
+++ b/wpa_supplicant/scan.c
@@ -1474,6 +1474,7 @@ int wpa_supplicant_req_sched_scan(struct wpa_supplicant *wpa_s)
 	if (wildcard)
 		need_ssids++;
 
+	wpa_s->normal_scans = 1;
 	if (wpa_s->normal_scans < 3 &&
 	    (need_ssids <= wpa_s->max_scan_ssids ||
 	     wpa_s->max_scan_ssids >= (int) max_sched_scan_ssids)) {


### PR DESCRIPTION
* disable the transition from normal to sched_scan