### PR TITLE
Ensure debug prints reach syslog

### DIFF
--- a/hostapd/config_file.c
+++ b/hostapd/config_file.c
@@ -2445,7 +2445,7 @@ static void inf_auth_print_params(struct infiot_auth_params *auth)
 	int ii = 0;
 	int num_users = auth->num_users;
 	for (ii = 0; ii < num_users; ii++) {
-		wpa_printf(MSG_INFO, "INFAUTH user %d is %s",
+		inf_wpa_printf(MSG_INFO, "INFAUTH user %d is %s",
 				   ii,
 				   auth->user_list[ii]);
 	}
@@ -2459,7 +2459,7 @@ static int inf_auth_parse_params(struct infiot_auth_params *auth, char *pos)
 	int idx = 0;
 
 	if (strlen(pos) == 0) {
-		wpa_printf(MSG_WARNING, "INFAUTH: User list is empty");
+		inf_wpa_printf(MSG_WARNING, "INFAUTH: User list is empty");
 		return 0;
 	}
 
@@ -2478,7 +2478,7 @@ static int inf_auth_parse_params(struct infiot_auth_params *auth, char *pos)
 	char **user_list;
 	user_list = os_calloc(sizeof(char *), num_users + 1);
 	if (user_list == NULL) {
-		wpa_printf(MSG_WARNING, "INFAUTH: unable to allocate memory for "
+		inf_wpa_printf(MSG_WARNING, "INFAUTH: unable to allocate memory for "
 				   "User lists, ignoring reading the User lists");
 		return 0;
 	}
@@ -2489,7 +2489,7 @@ static int inf_auth_parse_params(struct infiot_auth_params *auth, char *pos)
 			name_len = tok_start - tok_prev;
 			user_list[idx] = os_calloc(1, name_len + 1);
 			if (user_list[idx] == NULL) {
-				wpa_printf(MSG_WARNING, "INFAUTH: unable to parse a "
+				inf_wpa_printf(MSG_WARNING, "INFAUTH: unable to parse a "
 						   "User list (j=%d), skipping", j);
 				continue;
 			}
@@ -2504,7 +2504,7 @@ static int inf_auth_parse_params(struct infiot_auth_params *auth, char *pos)
 			name_len = os_strlen(tok_prev);
 			user_list[idx] = os_calloc(1, name_len + 1);
 			if (user_list[idx] == NULL) {
-				wpa_printf(MSG_WARNING, "INFAUTH: unable to parse a "
+				inf_wpa_printf(MSG_WARNING, "INFAUTH: unable to parse a "
 						   "User list (j=%d), skipping", j);
 				continue;
 			}

--- a/hostapd/config_file.h
+++ b/hostapd/config_file.h
@@ -19,4 +19,8 @@ int hostapd_add_acl_maclist(struct mac_acl_entry **acl, int *num,
 void hostapd_remove_acl_mac(struct mac_acl_entry **acl, int *num,
 			    const u8 *addr);
 
+#ifdef CONFIG_INF_AUTH
+void inf_wpa_printf(int level, const char *fmt, ...);
+#endif
+
 #endif /* CONFIG_FILE_H */

--- a/src/ap/ap_config.c
+++ b/src/ap/ap_config.c
@@ -692,7 +692,7 @@ static void hostapd_config_free_inf_auth_members(struct hostapd_bss_config *bss)
 	}
 
 	if (bss->inf_auth == NULL) {
-		wpa_printf(MSG_WARNING, "INFAUTH: Auth members is NULL when "
+		inf_wpa_printf(MSG_WARNING, "INFAUTH: Auth members is NULL when "
 				   "num_auth_params is %d",
 				   bss->inf_num_auth_params);
 		return;


### PR DESCRIPTION
When hostapd is running as a daemon, debug prints don't get to
syslog. Use the print API that ensures that this is done.